### PR TITLE
Improved overall UI of SignUp Page .

### DIFF
--- a/lib/screens/player/forms/player_form.dart
+++ b/lib/screens/player/forms/player_form.dart
@@ -115,7 +115,7 @@ class _PlayerFormState extends State<PlayerForm> {
         child: Container(
           padding: EdgeInsets.only(top: 24),
           alignment: Alignment.topCenter,
-          color: CustomColors.firebaseNavy,
+          color: CustomColors.primaryColor,
           child: Column(
             children: [
               Container(


### PR DESCRIPTION
## Hey I've beautified the UI of the SIgnUp page according to the apps theme. 
### Some of my changes include - 
* Used 3 UI theme colors instead of 2.
* Removed app bar and put a title text instead.
* Used Yellow color a bit more. Register Button and title text are in yellow now.
* Made the user profile picture in a circle against of a square.
* Changed the text form fields to the apps theme.

# Before
<img src="https://user-images.githubusercontent.com/24658039/136373480-c88442d1-46a5-4394-a1be-745b9c9363d8.PNG" align="center" alt="before " width="350" height="700">

# After

<img src="https://user-images.githubusercontent.com/24658039/136373628-6bfb807c-b734-4706-9254-d3ad04deb560.png" align="center" alt="before " width="350" height="700">

<img src="https://user-images.githubusercontent.com/24658039/136373641-514be44d-8558-47d2-acd6-0de0caa86227.png" align="center" alt="before " width="350" height="700">
 
Also if would mean alot if you add the hacktoberfest accepted label while merging !